### PR TITLE
Support promise implementations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osskit/monitor",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "repository": {
     "url": "https://github.com/osskit/monitor"
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "prom-client": ">=14.0.1"
   },
   "dependencies": {
+    "@sindresorhus/is": "^4.6.0",
     "pino": "^7.9.2"
   },
   "devDependencies": {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1,4 +1,5 @@
 import { Counter, Histogram } from 'prom-client';
+import is from '@sindresorhus/is';
 import logger from './logger';
 import safe from './safe';
 
@@ -53,8 +54,6 @@ export const setGlobalOptions = ({ logExecutionStart, logResult, parseError, pro
   global.prometheusBuckets = prometheusBuckets;
 };
 
-const isAPromiseLike = <T>(obj: any): obj is PromiseLike<T> => typeof obj === 'object' && typeof obj.then === 'function';
-
 const monitor = <T>({ scope: monitorScope, method, callable, options }: Monitor<T>) => {
   const metric = monitorScope ?? method;
   const scope = monitorScope ? `${monitorScope}.${method}` : method;
@@ -89,7 +88,7 @@ const monitor = <T>({ scope: monitorScope, method, callable, options }: Monitor<
     }
     const result = callable();
 
-    if (!isAPromiseLike<T>(result)) {
+    if (!is.promise(result)) {
       const executionTime = stopTimer();
 
       counter.inc({ method, result: 'success' });
@@ -108,7 +107,7 @@ const monitor = <T>({ scope: monitorScope, method, callable, options }: Monitor<
       return result;
     }
 
-    return Promise.resolve(result)
+    return result
       .then(async (promiseResult) => {
         const executionTime = stopTimer();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,6 +95,11 @@
   resolved "https://registry.yarnpkg.com/@osskit/prettier-config/-/prettier-config-0.0.1.tgz#f3e7751e694c53b9f376dd78e01fd4d94536261b"
   integrity sha512-kmu9L9TDczSG4TvVDMveZ/6oi2GtzZa2Oyw8zoup9F/SHNXiszjAhuTcZeCggA1XaoFanr9Wa4xopa/PGoV89g==
 
+"@sindresorhus/is@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"


### PR DESCRIPTION
In case the `callable` function returns a type which implements promise we would like to support it instead of checking `instanceOf Promise` (which will fail).