### PR TITLE
Allow overriding the log level for errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ setGlobalOptions({
   parseError: (res) => console.log(res),
   prometheusBuckets: [0.0001, 0.1, 0.5, 10],
   logger,
+  errorLogLevel: 'fatal'
 });
 
 setGlobalContext(() => getDynamicContext());
@@ -96,23 +97,26 @@ Invoke a function that returns a global context to use in all monitor invocation
 
 #### MonitorOptions
 
-|            Parameter            | Description                                                    |
-|:-------------------------------:|----------------------------------------------------------------|
-|       `context?: boolean`       | add context that will be logged in all method's logs           | 
-|      `logResult?: boolean`      | log the method's result                                        | 
-|  `logExecutionStart?: boolean`  | log the start of the method's execution `method.start`         |
-| `parseResult?: (e: any) => any` | transform the method's result that will be returned            |
-| `parseError?: (e: any) => any`  | if the method errored, transform the error that will be thrown |
+|            Parameter            | Description                                                                 |
+|:-------------------------------:|-----------------------------------------------------------------------------|
+|       `context?: boolean`       | add context that will be logged in all method's logs                        | 
+|      `logResult?: boolean`      | log the method's result                                                     | 
+|  `logExecutionStart?: boolean`  | log the start of the method's execution `method.start`                      |
+| `parseResult?: (e: any) => any` | transform the method's result that will be returned                         |
+| `parseError?: (e: any) => any`  | if the method errored, transform the error that will be thrown              |
+| `errorLogLevel?: pino.Level`    | if the method errored, which level should the message be, default - `error` |
+
 
 #### GlobalOptions
   
-|           Parameter            | Description                                                                 |
-|:------------------------------:|-----------------------------------------------------------------------------|
-|     `logResult?: boolean`      | log the monitored methods results                                           | 
-| `logExecutionStart?: boolean`  | log the start of the method's execution `method.start`                      |
-| `parseError?: (e: any) => any` | if the method errored, transform the error that will be thrown              |
-| `prometheusBuckets?: number[]` | use the following prometheus bucket list for monitor metrics across methods |
-|     `logger?: BaseLogger`      | supply a `pino` `BaseLogger` for monitor to use in logging results          |
-  
+|           Parameter            | Description                                                                  |
+|:------------------------------:|------------------------------------------------------------------------------|
+|     `logResult?: boolean`      | log the monitored methods results                                            | 
+| `logExecutionStart?: boolean`  | log the start of the method's execution `method.start`                       |
+| `parseError?: (e: any) => any` | if the method errored, transform the error that will be thrown               |
+| `prometheusBuckets?: number[]` | use the following prometheus bucket list for monitor metrics across methods  |
+|     `logger?: BaseLogger`      | supply a `pino` `BaseLogger` for monitor to use in logging results           |
+| `errorLogLevel?: pino.Level`    | if the method errored, which level should the message be, default - `error` |
+
 ## License
 [MIT License](LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osskit/monitor",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "repository": {
     "url": "https://github.com/osskit/monitor"
   },

--- a/src/globalOptions.ts
+++ b/src/globalOptions.ts
@@ -1,3 +1,4 @@
+import type { Level } from 'pino';
 import pino from 'pino';
 import type { GlobalOptions } from './types.js';
 import defaultLogger from './logger.js';
@@ -7,6 +8,7 @@ export let logResult = false;
 export let logExecutionStart = false;
 export let parseError: (e: any) => any = (e: any) => e;
 export let prometheusBuckets: number[] = [0.003, 0.03, 0.1, 0.3, 1.5, 10];
+export let errorLogLevel: Level = 'error';
 
 export let logger: BaseLogger = defaultLogger;
 
@@ -16,6 +18,7 @@ export const setGlobalOptions = ({
   parseError: optionalParseError,
   prometheusBuckets: optionalPrometheusBuckets,
   logger: optionalLogger,
+  errorLogLevel: optionalErrorLogLevel,
 }: Partial<GlobalOptions>) => {
   if (optionalLogger) {
     logger = optionalLogger;
@@ -35,5 +38,9 @@ export const setGlobalOptions = ({
 
   if (optionalParseError) {
     parseError = optionalParseError;
+  }
+
+  if (optionalErrorLogLevel) {
+    errorLogLevel = optionalErrorLogLevel;
   }
 };

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -4,6 +4,7 @@ import {
   logResult as globalLogResult,
   logExecutionStart as globalLogExecutionStart,
   parseError as globalParseError,
+  errorLogLevel as globalErrorLogLevel,
 } from './globalOptions.js';
 import { createCounter, createHistogram } from './prometheus.js';
 import { getGlobalContext } from './globalContext.js';
@@ -32,6 +33,7 @@ const innerMonitor = <Callable>({ scope: monitorScope, method: monitorMethod, ca
   const logExecutionStart = options?.logExecutionStart ?? globalLogExecutionStart;
   const logResult = options?.logResult ?? globalLogResult;
   const parseError = options?.parseError ?? globalParseError;
+  const errorLogLevel = options?.errorLogLevel ?? globalErrorLogLevel;
 
   try {
     if (logExecutionStart) {
@@ -87,7 +89,7 @@ const innerMonitor = <Callable>({ scope: monitorScope, method: monitorMethod, ca
       })
       .catch(async (error: Error) => {
         counter.inc({ method, result: 'error' });
-        logger.info(
+        logger[errorLogLevel](
           {
             extra: {
               context: { ...getGlobalContext?.(), ...options?.context },
@@ -100,7 +102,7 @@ const innerMonitor = <Callable>({ scope: monitorScope, method: monitorMethod, ca
       }) as any as Callable;
   } catch (error) {
     counter.inc({ method, result: 'error' });
-    logger.info(
+    logger[errorLogLevel](
       {
         extra: { context: { ...getGlobalContext?.(), ...options?.context }, error: safe(parseError)(error) },
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { BaseLogger } from 'pino';
+import type { BaseLogger, Level } from 'pino';
 
 export interface GlobalOptions extends MonitorOptionsBase {
   prometheusBuckets: number[];
@@ -17,6 +17,7 @@ export interface MonitorOptionsBase {
   logResult?: boolean;
   logExecutionStart?: boolean;
   parseError?: (e: any) => any;
+  errorLogLevel?: Level;
 }
 
 export interface MonitorOptions<T> extends MonitorOptionsBase {

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -127,6 +127,32 @@ describe('monitor', () => {
       );
     });
 
+    it('should write error log at error level', () => {
+      const logger: BaseLogger = {
+        level: 'info',
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        fatal: jest.fn(),
+        silent: jest.fn(),
+        trace: jest.fn(),
+        warn: jest.fn(),
+      };
+
+      setGlobalOptions({ logger, parseError: (error) => error.message });
+
+      const scoped = createMonitor({ scope: 'scope' });
+
+      try {
+        scoped('logs', () => {
+          throw new Error('some error');
+        });
+        // eslint-disable-next-line no-empty
+      } catch {}
+
+      expect(logger.error).toHaveBeenCalledWith({ extra: { context: {}, error: expect.any(String) } }, 'scope.logs.error');
+    });
+
     it('should write error log at trace level', () => {
       const logger: BaseLogger = {
         level: 'info',

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -143,12 +143,11 @@ describe('monitor', () => {
 
       const scoped = createMonitor({ scope: 'scope' });
 
-      try {
+      expect(() =>
         scoped('logs', () => {
           throw new Error('some error');
-        });
-        // eslint-disable-next-line no-empty
-      } catch {}
+        }),
+      ).toThrow();
 
       expect(logger.error).toHaveBeenCalledWith({ extra: { context: {}, error: expect.any(String) } }, 'scope.logs.error');
     });
@@ -169,12 +168,11 @@ describe('monitor', () => {
 
       const scoped = createMonitor({ scope: 'scope' });
 
-      try {
+      expect(() =>
         scoped('logs', () => {
           throw new Error('some error');
-        });
-        // eslint-disable-next-line no-empty
-      } catch {}
+        }),
+      ).toThrow();
 
       expect(logger.trace).toHaveBeenCalledWith({ extra: { context: {}, error: expect.any(String) } }, 'scope.logs.error');
     });

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -126,5 +126,31 @@ describe('monitor', () => {
         'scope.logs.success',
       );
     });
+
+    it('should write error log at trace level', () => {
+      const logger: BaseLogger = {
+        level: 'info',
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        fatal: jest.fn(),
+        silent: jest.fn(),
+        trace: jest.fn(),
+        warn: jest.fn(),
+      };
+
+      setGlobalOptions({ logger, errorLogLevel: 'trace', parseError: (error) => error.message });
+
+      const scoped = createMonitor({ scope: 'scope' });
+
+      try {
+        scoped('logs', () => {
+          throw new Error('some error');
+        });
+        // eslint-disable-next-line no-empty
+      } catch {}
+
+      expect(logger.trace).toHaveBeenCalledWith({ extra: { context: {}, error: expect.any(String) } }, 'scope.logs.error');
+    });
   });
 });


### PR DESCRIPTION
Currently, error logs were being logged as `info` level.
We want to start logging them at `error` level but also users to override this level.