### PR TITLE
add ability to disable metrics output

### DIFF
--- a/src/globalOptions.ts
+++ b/src/globalOptions.ts
@@ -9,6 +9,7 @@ export let logExecutionStart = false;
 export let parseError: (e: any) => any = (e: any) => e;
 export let prometheusBuckets: number[] = [0.003, 0.03, 0.1, 0.3, 1.5, 10];
 export let errorLogLevel: Level = 'error';
+export let metrics = true;
 
 export let logger: BaseLogger = defaultLogger;
 
@@ -19,6 +20,7 @@ export const setGlobalOptions = ({
   prometheusBuckets: optionalPrometheusBuckets,
   logger: optionalLogger,
   errorLogLevel: optionalErrorLogLevel,
+  metrics: optionalMetrics,
 }: Partial<GlobalOptions>) => {
   if (optionalLogger) {
     logger = optionalLogger;
@@ -42,5 +44,9 @@ export const setGlobalOptions = ({
 
   if (optionalErrorLogLevel) {
     errorLogLevel = optionalErrorLogLevel;
+  }
+
+  if (optionalMetrics !== undefined) {
+    metrics = optionalMetrics;
   }
 };

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -5,6 +5,7 @@ import {
   logExecutionStart as globalLogExecutionStart,
   parseError as globalParseError,
   errorLogLevel as globalErrorLogLevel,
+  metrics as globalMetrics,
 } from './globalOptions.js';
 import { createCounter, createHistogram } from './prometheus.js';
 import { getGlobalContext } from './globalContext.js';
@@ -23,18 +24,22 @@ const innerMonitor = <Callable>({ scope: monitorScope, method: monitorMethod, ca
   const errorLogLevel = options?.errorLogLevel ?? globalErrorLogLevel;
   const labelingKeys = Object.keys(labeling ?? {});
 
-  const counter = createCounter({
-    name: `${metric}_count`,
-    help: `${metric}_count`,
-    labelNames: ['method', 'result', ...labelingKeys],
-  });
-  const histogram = createHistogram({
-    name: `${metric}_execution_time`,
-    help: `${metric}_execution_time`,
-    labelNames: ['method', 'result', ...labelingKeys],
-  });
+  const counter = globalMetrics
+    ? createCounter({
+        name: `${metric}_count`,
+        help: `${metric}_count`,
+        labelNames: ['method', 'result', ...labelingKeys],
+      })
+    : undefined;
+  const histogram = globalMetrics
+    ? createHistogram({
+        name: `${metric}_execution_time`,
+        help: `${metric}_execution_time`,
+        labelNames: ['method', 'result', ...labelingKeys],
+      })
+    : undefined;
 
-  const stopTimer = histogram.startTimer();
+  const stopTimer = histogram?.startTimer();
 
   try {
     if (logExecutionStart) {
@@ -50,10 +55,12 @@ const innerMonitor = <Callable>({ scope: monitorScope, method: monitorMethod, ca
     const result = callable();
 
     if (!is.promise(result)) {
-      const executionTime = stopTimer();
+      const executionTime = stopTimer?.();
       const parsedResult = safe(options?.parseResult)(result);
-      counter.inc({ ...labeling, method, result: 'success' });
-      histogram.observe({ ...labeling, method, result: 'success' }, executionTime);
+      counter?.inc({ ...labeling, method, result: 'success' });
+      if (executionTime !== undefined) {
+        histogram?.observe({ ...labeling, method, result: 'success' }, executionTime);
+      }
       logger.info(
         {
           extra: {
@@ -70,10 +77,12 @@ const innerMonitor = <Callable>({ scope: monitorScope, method: monitorMethod, ca
 
     return result
       .then(async (promiseResult) => {
-        const executionTime = stopTimer();
+        const executionTime = stopTimer?.();
         const parsedResult = safe(options?.parseResult)(promiseResult);
-        counter.inc({ ...labeling, method, result: 'success' });
-        histogram.observe({ ...labeling, method, result: 'success' }, executionTime);
+        counter?.inc({ ...labeling, method, result: 'success' });
+        if (executionTime !== undefined) {
+          histogram?.observe({ ...labeling, method, result: 'success' }, executionTime);
+        }
 
         logger.info(
           {
@@ -89,7 +98,7 @@ const innerMonitor = <Callable>({ scope: monitorScope, method: monitorMethod, ca
         return promiseResult;
       })
       .catch(async (error: Error) => {
-        counter.inc({ ...labeling, method, result: 'error' });
+        counter?.inc({ ...labeling, method, result: 'error' });
         logger[errorLogLevel](
           {
             extra: {
@@ -102,7 +111,7 @@ const innerMonitor = <Callable>({ scope: monitorScope, method: monitorMethod, ca
         throw error;
       }) as any as Callable;
   } catch (error) {
-    counter.inc({ ...labeling, method, result: 'error' });
+    counter?.inc({ ...labeling, method, result: 'error' });
     logger[errorLogLevel](
       {
         extra: { context: { ...getGlobalContext?.(), ...options?.context }, error: safe(parseError)(error) },

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { BaseLogger, Level } from 'pino';
 export interface GlobalOptions extends MonitorOptionsBase {
   prometheusBuckets: number[];
   logger: BaseLogger;
+  metrics: boolean;
 }
 
 export interface InitOptions {

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -225,6 +225,68 @@ describe('monitor', () => {
       });
     });
 
+    it('should not create metrics when metrics is disabled', () => {
+      const logger: BaseLogger = {
+        level: 'info',
+        info: vi.fn<unknown[]>(),
+        debug: vi.fn<unknown[]>(),
+        error: vi.fn<unknown[]>(),
+        fatal: vi.fn<unknown[]>(),
+        silent: vi.fn<unknown[]>(),
+        trace: vi.fn<unknown[]>(),
+        warn: vi.fn<unknown[]>(),
+      };
+
+      setGlobalOptions({ logger, metrics: false });
+
+      const metricsBefore = register.getMetricsAsArray().length;
+
+      const scoped = createMonitor({ scope: 'noMetricsScope' });
+
+      expect(scoped('name', () => 5)).toBe(5);
+
+      const metricsAfter = register.getMetricsAsArray().length;
+
+      expect(metricsAfter).toBe(metricsBefore);
+      expect(logger.info).toHaveBeenCalledWith(
+        { extra: { context: {}, executionResult: undefined, executionTime: undefined } },
+        'noMetricsScope.name.success',
+      );
+
+      setGlobalOptions({ metrics: true });
+    });
+
+    it('should not create metrics for async functions when metrics is disabled', async () => {
+      const logger: BaseLogger = {
+        level: 'info',
+        info: vi.fn<unknown[]>(),
+        debug: vi.fn<unknown[]>(),
+        error: vi.fn<unknown[]>(),
+        fatal: vi.fn<unknown[]>(),
+        silent: vi.fn<unknown[]>(),
+        trace: vi.fn<unknown[]>(),
+        warn: vi.fn<unknown[]>(),
+      };
+
+      setGlobalOptions({ logger, metrics: false });
+
+      const metricsBefore = register.getMetricsAsArray().length;
+
+      const scoped = createMonitor({ scope: 'noMetricsScope' });
+
+      await expect(scoped('name', async () => 5)).resolves.toBe(5);
+
+      const metricsAfter = register.getMetricsAsArray().length;
+
+      expect(metricsAfter).toBe(metricsBefore);
+      expect(logger.info).toHaveBeenCalledWith(
+        { extra: { context: {}, executionResult: undefined, executionTime: undefined } },
+        'noMetricsScope.name.success',
+      );
+
+      setGlobalOptions({ metrics: true });
+    });
+
     it('should parse result', () => {
       const logger = {
         level: 'info',


### PR DESCRIPTION
## Summary
- Adds a `metrics` boolean option to `GlobalOptions` (defaults to `true`)
- When set to `false`, Prometheus counters and histograms are not created or recorded, while logs continue to work normally
- Adds tests for both sync and async functions with metrics disabled

## Usage
```ts
setGlobalOptions({ metrics: false });
```

## Test plan
- [x] All 15 existing tests pass
- [x] 2 new tests verify no metrics are created when `metrics: false` (sync & async)
- [x] Logs still fire when metrics are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)